### PR TITLE
Vscode remote support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "activationEvents": [
         "*"
     ],
+    "extensionKind": [
+        "ui"
+    ],
     "main": "./out/src/extension",
     "contributes": {
         "commands": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,17 +134,25 @@ class ActivityWatch {
     }
 
     private _getProjectFolder(): string | undefined {
-        const filePath = this._getFilePath();
-        if (!filePath) {
+        const fileUri = this._getActiveFileUri();
+        if (!fileUri) {
             return;
         }
-        const uri = Uri.file(filePath);
-        const workspaceFolder = workspace.getWorkspaceFolder(uri);
+        const workspaceFolder = workspace.getWorkspaceFolder(fileUri);
         if (!workspaceFolder) {
             return;
         }
 
         return workspaceFolder.uri.path;
+    }
+
+    private _getActiveFileUri(): Uri | undefined {
+        const editor = window.activeTextEditor;
+        if (!editor) {
+            return;
+        }
+
+        return editor.document.uri;
     }
 
     private _getFilePath(): string | undefined {


### PR DESCRIPTION
Fixes #17 

Testing has been pretty minimal, it works for me in code-insiders 1.52.0.

I noticed though that at the moment it only reports the project as the name of the workspace folder, seems that `workspaceFolder.uri.path` actually returns just the folder name instead of a full path. There is `uri.fsPath` that might return something more aligned with what was linked in #17 but I feel that's another change if that's wanted/needed.

Dashboard:
![image](https://user-images.githubusercontent.com/386551/100131157-574e9900-2e8c-11eb-954a-b1866f3698fe.png)
