### PR TITLE
feat: send workspace name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The source code is available at https://github.com/ActivityWatch/aw-watcher-vsco
 ## Features
 
 Sends following data to ActivityWatch:
+- current workspace name
 - current project name
 - programming language
 - current file name

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -141,7 +141,8 @@ class ActivityWatch {
                 language: this._getFileLanguage() || 'unknown',
                 project: this._getProjectFolder() || 'unknown',
                 file: this._getFilePath() || 'unknown',
-                branch: this._getCurrentBranch() || 'unknown'
+                branch: this._getCurrentBranch() || 'unknown',
+                workspace: workspace.name || 'unknown'
             }
         };
     }


### PR DESCRIPTION
This pull request would send the current workspace name to ActivityWatch.

It's useful to help categorization to understand how much time I'm spending on different workspaces that have repos with similar names (e.g. `server`).