### PR TITLE
Updated README.md to clarify WSL port forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ If you run into any errors or have feature requests, please [open an issue](http
 Calling out known issues can help limit users opening duplicate issues against your extension.
 -->
 
+## Notes on use with Windows Subsystem for Linux (WSL)
+
+If you are running Activity Watcher on your windows machine but work in vscode inside a WSL remote window aw-watcher-vscode will attempt to connect to the aw-server via localhost:5600 but since WSL runs on a different subnet than your windows machine port-forwarding IS required.
+
+This can be accomplished by locating the "PORTS" view under `View > Open View > Ports` and selecting `Add Port` then typing in `5600` (no quotes), this should auto-forward the WSL subnet's localhost port of 5600 to your Windows machines `localhost:5600` and show an origin of `User Forwarded`.
+
 ## Release Notes
 
 ### 0.5.0

--- a/README.md
+++ b/README.md
@@ -52,9 +52,18 @@ Calling out known issues can help limit users opening duplicate issues against y
 
 ## Notes on use with Windows Subsystem for Linux (WSL)
 
+#### <u>Problem</u>
 If you are running Activity Watcher on your windows machine but work in vscode inside a WSL remote window aw-watcher-vscode will attempt to connect to the aw-server via localhost:5600 but since WSL runs on a different subnet than your windows machine port-forwarding IS required.
 
+#### <u>Temporary Solution</u>
 This can be accomplished by locating the "PORTS" view under `View > Open View > Ports` and selecting `Add Port` then typing in `5600` (no quotes), this should auto-forward the WSL subnet's localhost port of 5600 to your Windows machines `localhost:5600` and show an origin of `User Forwarded`.
+
+#### <u>Permanent Solution</u>
+With the above described solution it is necessary to do so on each and every vscode workspace you open. If you would like to avoid having to manually forward the port each time you can follow the two simple steps listed below to permanently forward port `5600` to localhost.
+
+1. In your WSL shell run the command `ip a` and take note of WSL's IP Address, this will most likely be one of two IPs that appears, the 127.0.0.1 address is the loopback address and should NOT be used, take note of the other IP as it will be used in step two.
+2. Open powershell on your windows machine with admin privileges and run the following command, while remembering to replace `WSL_IP` with the IP address noted in step 1.
+    - `netsh interface portproxy add v4tov4 listenport=5600 connectport=5600 connectaddress=[WSL_IP]`
 
 ## Release Notes
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ If you are running Activity Watcher on your windows machine but work in vscode i
 This can be accomplished by locating the "PORTS" view under `View > Open View > Ports` and selecting `Add Port` then typing in `5600` (no quotes), this should auto-forward the WSL subnet's localhost port of 5600 to your Windows machines `localhost:5600` and show an origin of `User Forwarded`.
 
 #### Permanent Solution
-With the above described solution it is necessary to do so on each and every vscode workspace you open. If you would like to avoid having to manually forward the port each time you can follow the two simple steps listed below to permanently forward port `5600` to localhost.
+With the above described solution it is necessary to do so on each and every vscode workspace you open. If you would like to avoid having to manually forward the port each time you can follow the step listed below to permanently forward port `5600` to localhost.
 
-1. In your WSL shell run the command `ip a` and take note of WSL's IP Address, this will most likely be one of two IPs that appears, the 127.0.0.1 address is the loopback address and should NOT be used, take note of the other IP as it will be used in step two.
-2. Open powershell on your windows machine with admin privileges and run the following command, while remembering to replace `WSL_IP` with the IP address noted in step 1.
-    - `netsh interface portproxy add v4tov4 listenport=5600 connectport=5600 connectaddress=[WSL_IP]`
+1. Open powershell on your windows machine with admin privileges and run the following command.
+    - `netsh interface portproxy add v4tov4 listenport=5600 connectport=5600 connectaddress=*`
+
+    - <b>NOTE:</b> If `connectaddress` is set to the WSL IP address rather than `*` it will cause aw-server to fail to start.
 
 ## Release Notes
 

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ Calling out known issues can help limit users opening duplicate issues against y
 
 ## Notes on use with Windows Subsystem for Linux (WSL)
 
-#### <u>Problem</u>
+#### Problem
 If you are running Activity Watcher on your windows machine but work in vscode inside a WSL remote window aw-watcher-vscode will attempt to connect to the aw-server via localhost:5600 but since WSL runs on a different subnet than your windows machine port-forwarding IS required.
 
-#### <u>Temporary Solution</u>
+#### Temporary Solution
 This can be accomplished by locating the "PORTS" view under `View > Open View > Ports` and selecting `Add Port` then typing in `5600` (no quotes), this should auto-forward the WSL subnet's localhost port of 5600 to your Windows machines `localhost:5600` and show an origin of `User Forwarded`.
 
-#### <u>Permanent Solution</u>
+#### Permanent Solution
 With the above described solution it is necessary to do so on each and every vscode workspace you open. If you would like to avoid having to manually forward the port each time you can follow the two simple steps listed below to permanently forward port `5600` to localhost.
 
 1. In your WSL shell run the command `ip a` and take note of WSL's IP Address, this will most likely be one of two IPs that appears, the 127.0.0.1 address is the loopback address and should NOT be used, take note of the other IP as it will be used in step two.


### PR DESCRIPTION
Ref. #21 #18 #17 #9 

I recently installed activity watcher on my windows machine and ran into issues regarding port forwarding when running vscode inside WSL, it turns out that the plugin for vscode was trying to connect to port 5600 on WSL's subnet but not the local subnet of the windows machine running activity watch.

This can be resolved by manually forwarding the port inside each project or by running a shell command to permantly forward the port on WSL's end. I added both solutions to the README.md file in order to save others the trouble of having to figureo out what was going on and why activity watch had no idea that vscode inside WSL was not reporting any data. 

I did not look into how to modify the extension itself to auto-forward these ports but other extensions I have are able to do this so I am sure it's possible, just above my level of knowledge.

Thank you for all the work everyone has done in the creation of this extension, I hope my small documentation contribution will prove helpful to others.