### PR TITLE
feat: add HTTP Basic Auth support for nginx reverse proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,26 @@
             "type": "object",
             "title": "aw-watcher-vscode extension configuration",
             "properties": {
+                "aw-watcher-vscode.host": {
+                    "type": "string",
+                    "default": "",
+                    "description": "ActivityWatch server hostname. Leave empty for localhost."
+                },
+                "aw-watcher-vscode.port": {
+                    "type": "number",
+                    "default": 0,
+                    "description": "ActivityWatch server port. Set to 0 for default (5600)."
+                },
+                "aw-watcher-vscode.authUser": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Username for HTTP Basic Auth (for nginx-proxied servers)."
+                },
+                "aw-watcher-vscode.authPassword": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Password for HTTP Basic Auth (for nginx-proxied servers)."
+                },
                 "aw-watcher-vscode.maxHeartbeatsPerSec": {
                     "type": "number",
                     "default": 1,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,8 +50,28 @@ class ActivityWatch {
         };
         this._bucket.id = `${this._bucket.clientName}_${this._bucket.hostName}`;
 
+        // Read server configuration
+        const extConfig = workspace.getConfiguration('aw-watcher-vscode');
+        const host = extConfig.get<string>('host') || '';
+        const port = extConfig.get<number>('port') || 0;
+        const authUser = extConfig.get<string>('authUser') || '';
+        const authPassword = extConfig.get<string>('authPassword') || '';
+
+        // Build client options
+        const clientOptions: any = { testing: false };
+        if (host) {
+            const effectivePort = port || 5600;
+            clientOptions.baseURL = `http://${host}:${effectivePort}`;
+        }
+
         // Create AWClient
-        this._client = new AWClient(this._bucket.clientName, { testing: false });
+        this._client = new AWClient(this._bucket.clientName, clientOptions);
+
+        // Inject Basic Auth into axios instance if configured
+        if (authUser && authPassword) {
+            const token = Buffer.from(`${authUser}:${authPassword}`).toString('base64');
+            this._client.req.defaults.headers.common['Authorization'] = `Basic ${token}`;
+        }
 
         // subscribe to VS Code Events
         let subscriptions: Disposable[] = [];


### PR DESCRIPTION
## Summary

Add HTTP Basic Auth support for connecting to ActivityWatch servers behind an nginx reverse proxy with `auth_basic`.

## Changes

- Add `host`, `port`, `authUser`, `authPassword` settings to `package.json` configuration
- Read settings in `extension.ts` constructor
- Inject `Authorization: Basic` header into the axios instance after AWClient creation

## Usage

```json
{
    "aw-watcher-vscode.host": "your-server.example.com",
    "aw-watcher-vscode.port": 5601,
    "aw-watcher-vscode.authUser": "username",
    "aw-watcher-vscode.authPassword": "password"
}
```

No changes to the `aw-client-js` submodule required — auth is injected directly into the axios instance's default headers.